### PR TITLE
feat: respect map HashIncludeMap interface

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -206,9 +206,13 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 
 	case reflect.Map:
 		var includeMap IncludableMap
-		if opts != nil && opts.Struct != nil {
+		var field string
+
+		if v, ok := v.Interface().(IncludableMap); ok {
+			includeMap = v
+		} else if opts != nil && opts.Struct != nil {
 			if v, ok := opts.Struct.(IncludableMap); ok {
-				includeMap = v
+				includeMap, field = v, opts.StructField
 			}
 		}
 
@@ -218,8 +222,7 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 		for _, k := range v.MapKeys() {
 			v := v.MapIndex(k)
 			if includeMap != nil {
-				incl, err := includeMap.HashIncludeMap(
-					opts.StructField, k.Interface(), v.Interface())
+				incl, err := includeMap.HashIncludeMap(field, k.Interface(), v.Interface())
 				if err != nil {
 					return 0, err
 				}

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -576,6 +576,23 @@ func TestHash_includableMap(t *testing.T) {
 			testIncludableMap{Map: map[string]string{"bar": "baz"}},
 			false,
 		},
+		{
+			testIncludableMapMap{"foo": "bar"},
+			testIncludableMapMap{"foo": "bar"},
+			true,
+		},
+
+		{
+			testIncludableMapMap{"foo": "bar", "ignore": "true"},
+			testIncludableMapMap{"foo": "bar"},
+			true,
+		},
+
+		{
+			testIncludableMapMap{"foo": "bar", "ignore": "true"},
+			testIncludableMapMap{"bar": "baz"},
+			false,
+		},
 	}
 
 	for _, tc := range cases {
@@ -727,4 +744,10 @@ func (t *testHashablePointer) Hash() (uint64, error) {
 	}
 
 	return 100, nil
+}
+
+type testIncludableMapMap map[string]string
+
+func (t testIncludableMapMap) HashIncludeMap(_ string, k, _ interface{}) (bool, error) {
+	return k.(string) != "ignore", nil
 }


### PR DESCRIPTION
Without this functionality, a map must be added to a struct to exclude certain keys from the hashing process.