### PR TITLE
Use SetIterKey/SetIterValue

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -220,12 +220,16 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 		// and value hashes. This makes it deterministic despite ordering.
 		var h uint64
 
+		k := reflect.New(v.Type().Key()).Elem()
+		vv := reflect.New(v.Type().Elem()).Elem()
+
 		iter := v.MapRange()
+
 		for iter.Next() {
-			k := iter.Key()
-			v := iter.Value()
+			k.SetIterKey(iter)
+			vv.SetIterValue(iter)
 			if includeMap != nil {
-				incl, err := includeMap.HashIncludeMap(field, k.Interface(), v.Interface())
+				incl, err := includeMap.HashIncludeMap(field, k.Interface(), vv.Interface())
 				if err != nil {
 					return 0, err
 				}
@@ -238,7 +242,7 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 			if err != nil {
 				return 0, err
 			}
-			vh, err := w.visit(v, nil)
+			vh, err := w.visit(vv, nil)
 			if err != nil {
 				return 0, err
 			}


### PR DESCRIPTION
Compared to previous commit:

```
       │ stash.bench │        fix-setiterval.bench        │
       │   sec/op    │   sec/op     vs base               │
Map-10   3.159µ ± 1%   2.609µ ± 1%  -17.44% (p=0.002 n=6)

       │ stash.bench │       fix-setiterval.bench        │
       │    B/op     │    B/op     vs base               │
Map-10   1360.0 ± 0%   752.0 ± 0%  -44.71% (p=0.002 n=6)

       │ stash.bench │       fix-setiterval.bench        │
       │  allocs/op  │ allocs/op   vs base               │
Map-10   128.00 ± 0%   90.00 ± 0%  -29.69% (p=0.002 n=6)
```

Compared to 1dee3c38213ce142b02cf6ede54e75d872f892df:

```
       │ 1dee3c38213ce142b02cf6ede54e75d872f892df.bench │        fix-setiterval.bench        │
       │                     sec/op                     │   sec/op     vs base               │
Map-10                                      3.608µ ± 1%   2.537µ ± 1%  -29.68% (p=0.002 n=6)

       │ 1dee3c38213ce142b02cf6ede54e75d872f892df.bench │       fix-setiterval.bench        │
       │                      B/op                      │    B/op     vs base               │
Map-10                                      1888.0 ± 0%   752.0 ± 0%  -60.17% (p=0.002 n=6)

       │ 1dee3c38213ce142b02cf6ede54e75d872f892df.bench │       fix-setiterval.bench        │
       │                   allocs/op                    │ allocs/op   vs base               │
Map-10                                      130.00 ± 0%   90.00 ± 0%  -30.77% (p=0.002 n=6)
````
