### PR TITLE
Some performance optimizations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/gohugoio/hashstructure
 
 go 1.18
+
+require github.com/cespare/xxhash/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/cespare/xxhash/v2"
 )
 
 func TestHash_identity(t *testing.T) {
@@ -727,6 +729,7 @@ func TestHash_golden(t *testing.T) {
 			In:     int64(42),
 			Expect: 11375694726533372055,
 		},
+
 		{
 			In:     uint16(42),
 			Expect: 590708257076254031,
@@ -844,6 +847,22 @@ func BenchmarkMap(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Hash(m, nil)
 	}
+}
+
+func BenchmarkString(b *testing.B) {
+	s := "lorem ipsum dolor sit amet"
+	b.Run("default", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			Hash(s, nil)
+		}
+	})
+
+	b.Run("xxhash", func(b *testing.B) {
+		opts := &HashOptions{Hasher: xxhash.New()}
+		for i := 0; i < b.N; i++ {
+			Hash(s, opts)
+		}
+	})
 }
 
 type testIncludable struct {


### PR DESCRIPTION
* Avoid creating new `reflect.Value`s for common int, uint and bool types.
* Use `io.WriteString` to write strings. This uses `io.StringWriter` if it exists, which is  implemented by e.g. github.com/cespare/xxhash.

Compared to master:

```
goos: darwin
goarch: arm64
pkg: github.com/gohugoio/hashstructure
cpu: Apple M1 Pro
                  │ cmpmaster.bench │         perf-20250205.bench         │
                  │     sec/op      │    sec/op     vs base               │
Map-10                 1.963µ ± 17%   1.291µ ± 13%  -34.23% (p=0.002 n=6)
String/default-10      80.90n ±  1%   84.41n ±  0%   +4.34% (p=0.002 n=6)
String/xxhash-10       54.83n ±  1%   40.12n ±  0%  -26.82% (p=0.002 n=6)
geomean                205.7n         163.5n        -20.52%

                  │ cmpmaster.bench │         perf-20250205.bench          │
                  │      B/op       │    B/op      vs base                 │
Map-10                  573.5 ± 22%   382.0 ± 13%  -33.39% (p=0.002 n=6)
String/default-10       56.00 ±  0%   56.00 ±  0%        ~ (p=1.000 n=6) ¹
String/xxhash-10        48.00 ±  0%   16.00 ±  0%  -66.67% (p=0.002 n=6)
geomean                 115.5         69.95        -39.45%
¹ all samples are equal

                  │ cmpmaster.bench │         perf-20250205.bench          │
                  │    allocs/op    │  allocs/op   vs base                 │
Map-10                  57.50 ± 20%   37.00 ± 14%  -35.65% (p=0.002 n=6)
String/default-10       3.000 ±  0%   3.000 ±  0%        ~ (p=1.000 n=6) ¹
String/xxhash-10        2.000 ±  0%   1.000 ±  0%  -50.00% (p=0.002 n=6)
geomean                 7.014         4.806        -31.48%
```

Compared to `mitchellh/hashstructure`:

```
goos: darwin
goarch: arm64
pkg: github.com/gohugoio/hashstructure
cpu: Apple M1 Pro
                  │ cmpfork.bench │         perf-20250205.bench         │
                  │    sec/op     │    sec/op     vs base               │
Map-10                2.789µ ± 6%   1.292µ ± 41%  -53.69% (p=0.002 n=6)
String/default-10     83.45n ± 0%   87.36n ±  1%   +4.69% (p=0.002 n=6)
String/xxhash-10      56.19n ± 0%   41.59n ±  1%  -25.98% (p=0.002 n=6)
geomean               235.6n        167.4n        -28.94%

                  │ cmpfork.bench │         perf-20250205.bench          │
                  │     B/op      │    B/op      vs base                 │
Map-10                1461.0 ± 6%   393.0 ± 27%  -73.10% (p=0.002 n=6)
String/default-10      56.00 ± 0%   56.00 ±  0%        ~ (p=1.000 n=6) ¹
String/xxhash-10       48.00 ± 0%   16.00 ±  0%  -66.67% (p=0.002 n=6)
geomean                157.8        70.62        -55.24%
¹ all samples are equal

                  │ cmpfork.bench │         perf-20250205.bench          │
                  │   allocs/op   │  allocs/op   vs base                 │
Map-10                 87.50 ± 9%   36.50 ± 40%  -58.29% (p=0.002 n=6)
String/default-10      3.000 ± 0%   3.000 ±  0%        ~ (p=1.000 n=6) ¹
String/xxhash-10       2.000 ± 0%   1.000 ±  0%  -50.00% (p=0.002 n=6)
geomean                8.067        4.784        -40.70%
````
