### PR TITLE
Add support for complex64/complex128

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -196,7 +196,7 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 		return w.hashDirect(v.Interface())
 	}
 
-	if v.CanFloat() {
+	if v.CanFloat() || v.CanComplex() {
 		return w.hashDirect(v.Interface())
 	}
 

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -751,6 +751,14 @@ func TestHash_golden(t *testing.T) {
 			Expect: 12162027084228238918,
 		},
 		{
+			In:     complex64(42),
+			Expect: 13187391128804187615,
+		},
+		{
+			In:     complex128(42),
+			Expect: 4635205179288363782,
+		},
+		{
 			In:     true,
 			Expect: 12638153115695167454,
 		},


### PR DESCRIPTION
Support for complex64 was accidentally removed in 72666c84d299423e672e13f061a2ef9e7131a169, complex128 is new. Now with tests.
