### PR TITLE
allocation performance optimizations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/gohugoio/hashstructure
 
-go 1.18
+go 1.20
 
 require github.com/cespare/xxhash/v2 v2.3.0


### PR DESCRIPTION
Hello there @bep.

One of the projects I'm working on makes heavy use of the hashstructure lib.

Since we're hashing rather big objects, I noticed huge allocation overhead in the library and did some optimizations.
In particular:
- Avoid using reflect.ValueOf for obvious string values
- Avoid allocating visitOps object in a loop
- Changes binary.Write to direct byte operations using a shared buffer for number types
- Use the unsafe pkg for zero copy binary writes for strings
- Only wrapping reflect.Value objects with v.Int(), v.Interface() etc. if absolutely necessary 

I'm not sure if this is a fork you intent to maintain as a library for others to use, but since I'm building on your previous improvements I thought this might be valuable to you.

Side Note: Those improvements where partly suggested by AI, but I carefully reviewed them and made sure objects we hash within our projects produce hashes consistent with the previous version.

Benchmark:

```
goos: darwin
goarch: arm64
pkg: github.com/gohugoio/hashstructure
cpu: Apple M4 Pro
                  │   old.txt    │               new.txt                │
                  │    sec/op    │    sec/op     vs base                │
Map-14              3.862µ ± 24%   2.752µ ± 19%  -28.74% (p=0.000 n=10)
String/default-14   63.02n ±  5%   48.54n ±  4%  -22.98% (p=0.000 n=10)
String/xxhash-14    33.85n ±  7%   30.54n ±  9%   -9.79% (p=0.007 n=10)
geomean             202.0n         159.8n        -20.89%

                  │   old.txt   │               new.txt                │
                  │    B/op     │    B/op     vs base                  │
Map-14              1113.0 ± 0%   665.0 ± 0%  -40.25% (p=0.000 n=10)
String/default-14    56.00 ± 0%   24.00 ± 0%  -57.14% (p=0.000 n=10)
String/xxhash-14     16.00 ± 0%   16.00 ± 0%        ~ (p=1.000 n=10) ¹
geomean              99.91        63.44       -36.50%
¹ all samples are equal

                  │   old.txt   │               new.txt                │
                  │  allocs/op  │ allocs/op   vs base                  │
Map-14              120.00 ± 0%   43.00 ± 0%  -64.17% (p=0.000 n=10)
String/default-14    3.000 ± 0%   2.000 ± 0%  -33.33% (p=0.000 n=10)
String/xxhash-14     1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean              7.114        4.414       -37.95%
¹ all samples are equal
```
