### PR TITLE
Update Go 1.24.x/1.25.x, GitHub Actions, go.mod Go 1.24, dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.24.x, 1.25.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install staticcheck
@@ -27,7 +27,7 @@ jobs:
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Fmt
         if: matrix.platform != 'windows-latest' # :(
         run: "diff <(gofmt -d .) <(printf '')"

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/gohugoio/hashstructure
 
-go 1.20
+go 1.24
 
 require github.com/cespare/xxhash/v2 v2.3.0


### PR DESCRIPTION
Updates: Go 1.24.x/1.25.x, GitHub Actions, go.mod Go 1.24, dependencies

---
Created by mygithelper