### PR TITLE
Fix hash collisions for sets containing duplicate elements

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -528,7 +528,7 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 			set = set || (opts.Flags&visitFlagSet) != 0
 		}
 		l := v.Len()
-		// In set mode, duplicate elements must be skipped: the hashes are
+		// In set mode, duplicate element hashes must be skipped: the hashes are
 		// combined with XOR, so an element repeated an even number of times
 		// cancels itself out, making e.g. {a, e, e} and {a, d, d} collide.
 		var seen map[uint64]struct{}

--- a/hashstructure.go
+++ b/hashstructure.go
@@ -523,18 +523,31 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 		// visit all the elements. If it is a set, then we do a deterministic
 		// hash code.
 		var h uint64
-		var set bool
+		set := w.sets
 		if opts != nil {
-			set = (opts.Flags & visitFlagSet) != 0
+			set = set || (opts.Flags&visitFlagSet) != 0
 		}
 		l := v.Len()
+		// In set mode, duplicate elements must be skipped: the hashes are
+		// combined with XOR, so an element repeated an even number of times
+		// cancels itself out, making e.g. {a, e, e} and {a, d, d} collide.
+		var seen map[uint64]struct{}
+		if set && l > 1 {
+			seen = make(map[uint64]struct{}, l)
+		}
 		for i := range l {
 			current, err := w.visit(v.Index(i), nil)
 			if err != nil {
 				return 0, err
 			}
 
-			if set || w.sets {
+			if set {
+				if seen != nil {
+					if _, ok := seen[current]; ok {
+						continue
+					}
+					seen[current] = struct{}{}
+				}
 				h = hashUpdateUnordered(h, current)
 			} else {
 				h = hashUpdateOrdered(w.h, h, current)

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -441,6 +441,59 @@ func TestHash_equalSet(t *testing.T) {
 	}
 }
 
+// Issue #10: two slices that differ only by an item repeated in both
+// must not hash to the same value.
+func TestHash_setWithDuplicates(t *testing.T) {
+	type Test struct {
+		Friends []string `hash:"set"`
+	}
+
+	cases := []struct {
+		One, Two any
+		Match    bool
+	}{
+		{
+			[]string{"a", "b", "c", "e", "e"},
+			[]string{"a", "b", "c", "d", "d"},
+			false,
+		},
+
+		{
+			Test{Friends: []string{"a", "b", "c", "e", "e"}},
+			Test{Friends: []string{"a", "b", "c", "d", "d"}},
+			false,
+		},
+
+		// Duplicates don't count in a set, and order doesn't matter.
+		{
+			[]string{"e", "a", "b", "c", "e"},
+			[]string{"a", "b", "c", "e"},
+			true,
+		},
+
+		{
+			Test{Friends: []string{"e", "a", "b", "c", "e"}},
+			Test{Friends: []string{"a", "b", "c", "e"}},
+			true,
+		},
+	}
+
+	c := qt.New(t)
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, &HashOptions{SlicesAsSets: true})
+		c.Assert(err, qt.IsNil, qt.Commentf("%#v", tc.One))
+		two, err := Hash(tc.Two, &HashOptions{SlicesAsSets: true})
+		c.Assert(err, qt.IsNil, qt.Commentf("%#v", tc.Two))
+
+		// Zero is always wrong
+		c.Assert(one, qt.Not(qt.Equals), uint64(0), qt.Commentf("%#v", tc.One))
+
+		// Compare
+		c.Assert(one == two, qt.Equals, tc.Match, qt.Commentf("%#v\n\n%#v", tc.One, tc.Two))
+	}
+}
+
 func TestHash_includable(t *testing.T) {
 	cases := []struct {
 		One, Two any

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -481,9 +481,13 @@ func TestHash_setWithDuplicates(t *testing.T) {
 	c := qt.New(t)
 
 	for _, tc := range cases {
-		one, err := Hash(tc.One, &HashOptions{SlicesAsSets: true})
+		opts := &HashOptions{SlicesAsSets: true}
+		if _, ok := tc.One.(Test); ok {
+			opts = nil
+		}
+		one, err := Hash(tc.One, opts)
 		c.Assert(err, qt.IsNil, qt.Commentf("%#v", tc.One))
-		two, err := Hash(tc.Two, &HashOptions{SlicesAsSets: true})
+		two, err := Hash(tc.Two, opts)
 		c.Assert(err, qt.IsNil, qt.Commentf("%#v", tc.Two))
 
 		// Zero is always wrong


### PR DESCRIPTION
In set mode, element hashes are combined with XOR, so an element
repeated an even number of times cancelled itself out, making e.g.
{a, e, e} and {a, d, d} hash to the same value. Skip duplicate
element hashes so slices get true set semantics.

Also apply the hashFinishUnordered hardening step to slices hashed
via the SlicesAsSets option, not just the `set` struct tag.

Fixes #10

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
