### PR TITLE
Misc performance improvements

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -7,6 +7,7 @@ import (
 	"hash/fnv"
 	"math"
 	"reflect"
+	"sync"
 	"time"
 	"unsafe"
 )
@@ -93,7 +94,8 @@ func Hash(v any, opts *HashOptions) (uint64, error) {
 		opts = &HashOptions{}
 	}
 	if opts.Hasher == nil {
-		opts.Hasher = fnv.New64()
+		opts.Hasher = getFnv()
+		defer putFnv(opts.Hasher)
 	}
 	if opts.TagName == "" {
 		opts.TagName = "hash"
@@ -615,3 +617,18 @@ const (
 	visitFlagInvalid visitFlag = iota
 	visitFlagSet               = iota << 1
 )
+
+var fnvPool = sync.Pool{
+	New: func() any {
+		return fnv.New64()
+	},
+}
+
+func getFnv() hash.Hash64 {
+	return fnvPool.Get().(hash.Hash64)
+}
+
+func putFnv(h hash.Hash64) {
+	h.Reset()
+	fnvPool.Put(h)
+}

--- a/hashstructure.go
+++ b/hashstructure.go
@@ -111,15 +111,9 @@ func Hash(v any, opts *HashOptions) (uint64, error) {
 	}
 
 	// Create our walker and walk the structure
-	w := &walker{
-		h:               opts.Hasher,
-		tag:             opts.TagName,
-		zeronil:         opts.ZeroNil,
-		ignorezerovalue: opts.IgnoreZeroValue,
-		sets:            opts.SlicesAsSets,
-		stringer:        opts.UseStringer,
-		unwrap:          opts.UnwrapFunc,
-	}
+	w := getWalker(opts.Hasher, opts)
+	defer putWalker(w)
+
 	return w.visit(reflect.ValueOf(v), nil)
 }
 
@@ -618,6 +612,36 @@ const (
 	visitFlagSet               = iota << 1
 )
 
+var walkerPool = sync.Pool{
+	New: func() any {
+		return &walker{}
+	},
+}
+
+func getWalker(h hash.Hash64, opts *HashOptions) *walker {
+	w := walkerPool.Get().(*walker)
+	w.h = h
+	w.tag = opts.TagName
+	w.zeronil = opts.ZeroNil
+	w.ignorezerovalue = opts.IgnoreZeroValue
+	w.sets = opts.SlicesAsSets
+	w.stringer = opts.UseStringer
+	w.unwrap = opts.UnwrapFunc
+	return w
+}
+
+func putWalker(w *walker) {
+	w.h = nil
+	w.tag = ""
+	w.zeronil = false
+	w.ignorezerovalue = false
+	w.sets = false
+	w.stringer = false
+	w.unwrap = nil
+
+	walkerPool.Put(w)
+}
+
 var fnvPool = sync.Pool{
 	New: func() any {
 		return fnv.New64()
@@ -629,6 +653,6 @@ func getFnv() hash.Hash64 {
 }
 
 func putFnv(h hash.Hash64) {
-	h.Reset()
+	// It will be reeset before it's used again.
 	fnvPool.Put(h)
 }

--- a/hashstructure.go
+++ b/hashstructure.go
@@ -343,7 +343,7 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 				return 0, err
 			}
 
-			h = hashUpdateOrdered(w.h, h, current)
+			h = w.hashUpdateOrdered(h, current)
 		}
 
 		return h, nil
@@ -391,12 +391,12 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 				return 0, err
 			}
 
-			fieldHash := hashUpdateOrdered(w.h, kh, vh)
-			h = hashUpdateUnordered(h, fieldHash)
+			fieldHash := w.hashUpdateOrdered(kh, vh)
+			h = w.hashUpdateUnordered(h, fieldHash)
 		}
 
 		// Important: read the docs for hashFinishUnordered
-		h = hashFinishUnordered(w.h, h)
+		h = w.hashFinishUnordered(h)
 
 		return h, nil
 
@@ -505,11 +505,11 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 					return 0, err
 				}
 
-				fieldHash := hashUpdateOrdered(w.h, kh, vh)
-				h = hashUpdateUnordered(h, fieldHash)
+				fieldHash := w.hashUpdateOrdered(kh, vh)
+				h = w.hashUpdateUnordered(h, fieldHash)
 			}
 			// Important: read the docs for hashFinishUnordered
-			h = hashFinishUnordered(w.h, h)
+			h = w.hashFinishUnordered(h)
 		}
 
 		return h, nil
@@ -544,15 +544,15 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 					}
 					seen[current] = struct{}{}
 				}
-				h = hashUpdateUnordered(h, current)
+				h = w.hashUpdateUnordered(h, current)
 			} else {
-				h = hashUpdateOrdered(w.h, h, current)
+				h = w.hashUpdateOrdered(h, current)
 			}
 		}
 
 		if set {
 			// Important: read the docs for hashFinishUnordered
-			h = hashFinishUnordered(w.h, h)
+			h = w.hashFinishUnordered(h)
 		}
 
 		return h, nil
@@ -564,19 +564,18 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 	}
 }
 
-func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {
+func (w *walker) hashUpdateOrdered(a, b uint64) uint64 {
 	// For ordered updates, use a real hash function
-	h.Reset()
+	w.h.Reset()
 
-	var buf [16]byte
-	binary.LittleEndian.PutUint64(buf[0:8], a)
-	binary.LittleEndian.PutUint64(buf[8:16], b)
-	h.Write(buf[:])
+	binary.LittleEndian.PutUint64(w.buf[0:8], a)
+	binary.LittleEndian.PutUint64(w.buf[8:16], b)
+	w.h.Write(w.buf[:])
 
-	return h.Sum64()
+	return w.h.Sum64()
 }
 
-func hashUpdateUnordered(a, b uint64) uint64 {
+func (w *walker) hashUpdateUnordered(a, b uint64) uint64 {
 	return a ^ b
 }
 
@@ -594,14 +593,14 @@ func hashUpdateUnordered(a, b uint64) uint64 {
 //
 // hashFinishUnordered "hardens" the result, so that encountering partially
 // overlapping input data later on in a different context won't cancel out.
-func hashFinishUnordered(h hash.Hash64, a uint64) uint64 {
-	h.Reset()
+func (w *walker) hashFinishUnordered(a uint64) uint64 {
+	w.h.Reset()
 
 	var buf [8]byte
 	binary.LittleEndian.PutUint64(buf[:], a)
-	h.Write(buf[:])
+	w.h.Write(buf[:])
 
-	return h.Sum64()
+	return w.h.Sum64()
 }
 
 // visitFlag is used as a bitmask for affecting visit behavior

--- a/hashstructure.go
+++ b/hashstructure.go
@@ -60,9 +60,10 @@ type HashOptions struct {
 // Hash returns the hash value of an arbitrary value.
 //
 // If opts is nil, then default options will be used. See HashOptions
-// for the default values. The same *HashOptions value cannot be used
-// concurrently. None of the values within a *HashOptions struct are
-// safe to read/write while hashing is being done.
+// for the default values. Hash treats opts as read-only, so the same
+// *HashOptions value can be shared and reused, also concurrently, as
+// long as its Hasher is nil: a hash.Hash64 is stateful, so a
+// *HashOptions carrying a custom Hasher must not be used concurrently.
 //
 // Notes on the value:
 //
@@ -89,29 +90,27 @@ type HashOptions struct {
 //   - "string" - The field will be hashed as a string, only works when the
 //     field implements fmt.Stringer
 func Hash(v any, opts *HashOptions) (uint64, error) {
-	// Create default options
 	if opts == nil {
 		opts = &HashOptions{}
 	}
-	if opts.Hasher == nil {
-		opts.Hasher = getFnv()
-		defer putFnv(opts.Hasher)
-	}
-	if opts.TagName == "" {
-		opts.TagName = "hash"
+
+	hasher := opts.Hasher
+	if hasher == nil {
+		hasher = getFnv()
+		defer putFnv(hasher)
 	}
 
-	// Reset the hash
-	opts.Hasher.Reset()
+	// No Reset of the hasher here: every function that touches it
+	// (hashString, hashDirect etc.) resets it before writing.
+	// Keep it that way if you add a new write site.
 
 	// Fast path for strings.
 	// This deliberately bypasses UnwrapFunc; see its documentation.
 	if s, ok := v.(string); ok {
-		return hashString(opts.Hasher, s)
+		return hashString(hasher, s)
 	}
 
-	// Create our walker and walk the structure
-	w := getWalker(opts.Hasher, opts)
+	w := getWalker(hasher, opts)
 	defer putWalker(w)
 
 	return w.visit(reflect.ValueOf(v), nil)
@@ -596,9 +595,8 @@ func (w *walker) hashUpdateUnordered(a, b uint64) uint64 {
 func (w *walker) hashFinishUnordered(a uint64) uint64 {
 	w.h.Reset()
 
-	var buf [8]byte
-	binary.LittleEndian.PutUint64(buf[:], a)
-	w.h.Write(buf[:])
+	binary.LittleEndian.PutUint64(w.buf[:8], a)
+	w.h.Write(w.buf[:8])
 
 	return w.h.Sum64()
 }
@@ -621,6 +619,9 @@ func getWalker(h hash.Hash64, opts *HashOptions) *walker {
 	w := walkerPool.Get().(*walker)
 	w.h = h
 	w.tag = opts.TagName
+	if w.tag == "" {
+		w.tag = "hash"
+	}
 	w.zeronil = opts.ZeroNil
 	w.ignorezerovalue = opts.IgnoreZeroValue
 	w.sets = opts.SlicesAsSets
@@ -652,6 +653,6 @@ func getFnv() hash.Hash64 {
 }
 
 func putFnv(h hash.Hash64) {
-	// It will be reeset before it's used again.
+	// It will be reset before it's used again.
 	fnvPool.Put(h)
 }

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -2,6 +2,7 @@ package hashstructure
 
 import (
 	"fmt"
+	"hash/fnv"
 	"reflect"
 	"strings"
 	"testing"
@@ -1057,6 +1058,34 @@ func BenchmarkMap(b *testing.B) {
 		opts := &HashOptions{UnwrapFunc: func(v reflect.Value) (reflect.Value, error) { return v, nil }}
 		for b.Loop() {
 			Hash(m, opts)
+		}
+	})
+}
+
+func BenchmarkStruct(b *testing.B) {
+	type testStruct struct {
+		Foo string
+	}
+
+	b.Run("value", func(b *testing.B) {
+		s := testStruct{Foo: "foo"}
+		for b.Loop() {
+			Hash(s, nil)
+		}
+	})
+
+	b.Run("pointer", func(b *testing.B) {
+		s := &testStruct{Foo: "foo"}
+		for b.Loop() {
+			Hash(s, nil)
+		}
+	})
+
+	b.Run("pointer predefined hasher", func(b *testing.B) {
+		s := &testStruct{Foo: "foo"}
+		opts := &HashOptions{Hasher: fnv.New64()}
+		for b.Loop() {
+			Hash(s, opts)
 		}
 	})
 }

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -975,6 +975,50 @@ func TestHash_golden(t *testing.T) {
 	}
 }
 
+func TestHash_slicesAsSet_golden(t *testing.T) {
+	cases := []struct {
+		In     any
+		Expect uint64
+	}{
+		{
+			In: struct {
+				Foo string
+				Bar []any
+			}{
+				Foo: "foo",
+				Bar: []any{nil, nil, nil},
+			},
+			Expect: 3717100187917615858,
+		},
+		{
+			In:     []any{1, 2, 3},
+			Expect: 2044210338600952799,
+		},
+		{
+			In:     []any{3, 2, 3, 3, 1},
+			Expect: 2044210338600952799,
+		},
+		{
+			In:     []string{"a", "b", "c", "e", "e"},
+			Expect: 14856124470027295614,
+		},
+		{
+			In:     []string{"a", "b", "c", "d", "d"},
+			Expect: 10627943203888361049,
+		},
+	}
+
+	c := qt.New(t)
+
+	for i, tc := range cases {
+		c.Run(fmt.Sprintf("%d", i), func(c *qt.C) {
+			got, err := Hash(tc.In, &HashOptions{SlicesAsSets: true})
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, tc.Expect)
+		})
+	}
+}
+
 func BenchmarkMap(b *testing.B) {
 	m := map[string]any{
 		"int16":      int16(42),

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -5,6 +5,7 @@ import (
 	"hash/fnv"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -972,6 +973,16 @@ func TestHash_golden(t *testing.T) {
 			got, err := Hash(tc.In, nil)
 			c.Assert(err, qt.IsNil)
 			c.Assert(got, qt.Equals, tc.Expect)
+
+			h := fnv.New64()
+			// Make sure the custom hasher is reset correctly.
+			h.Write([]byte("hello"))
+			opts := &HashOptions{Hasher: h}
+			for range 2 {
+				got, err := Hash(tc.In, opts)
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.Equals, tc.Expect)
+			}
 		})
 	}
 }
@@ -1018,6 +1029,49 @@ func TestHash_slicesAsSet_golden(t *testing.T) {
 			c.Assert(got, qt.Equals, tc.Expect)
 		})
 	}
+}
+
+func TestHash_concurrentSharedOptions(t *testing.T) {
+	c := qt.New(t)
+
+	type testStruct struct {
+		Foo string
+	}
+	v := testStruct{Foo: "foo"}
+
+	expect, err := Hash(v, nil)
+	c.Assert(err, qt.IsNil)
+
+	// Shared across goroutines without any warm-up call, so that any
+	// write to it inside Hash (Hasher, TagName) is caught by -race.
+	// See issue #23.
+	opts := &HashOptions{}
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Go(func() {
+			for j := range 1000 {
+				o := opts
+				if j%2 == 0 {
+					o = nil
+				}
+				got, err := Hash(v, o)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				if got != expect {
+					t.Errorf("hash mismatch: got %d, want %d", got, expect)
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	// Hash must have treated the shared options as read-only.
+	c.Assert(opts.Hasher, qt.IsNil)
+	c.Assert(opts.TagName, qt.Equals, "")
 }
 
 func BenchmarkMap(b *testing.B) {


### PR DESCRIPTION
## This PR compared to master

| Benchmark | time/op | Δ | B/op | Δ | allocs/op | Δ |
|---|---|---|---|---|---|---|
| Map/default | 2.25µ → 1.92µ | −15% | 632 → 64 | −90% | 39 → 4 | −90% |
| Map/no-op unwrap | 2.34µ → 2.00µ | −14% | 624 → 64 | −90% | 38 → 4 | −89% |
| Struct/value | 180n → 165n | −8% | 112 → 16 | −86% | 5 → 1 | −80% |
| Struct/pointer | 158n → 144n | −9% | 96 → 0 | −100% | 4 → 0 | −100% |
| Struct/pointer predefined hasher | 152n → 135n | −11% | 88 → 0 | −100% | 3 → 0 | −100% |
| String/default | 28.8n → 37.9n | +32% | 8 → 0 | −100% | 1 → 0 | −100% |
| String/xxhash | 16.5n → 13.0n | −22% | 0 → 0 | = | 0 → 0 | = |
| **geomean** | 195n → 180n | **−8%** | | | | |

## This PR compared to mitchellh/hashstructure

| Benchmark | time/op | Δ | B/op | Δ | allocs/op | Δ |
|---|---|---|---|---|---|---|
| Map/default | 2.96µ → 1.96µ | −34% | 1630 → 64 | −96% | 101 → 4 | −96% |
| Struct/value | 278n → 169n | −39% | 160 → 16 | −90% | 11 → 1 | −91% |
| Struct/pointer | 277n → 147n | −47% | 160 → 0 | −100% | 11 → 0 | −100% |
| Struct/pointer predefined hasher | 269n → 138n | −49% | 152 → 0 | −100% | 10 → 0 | −100% |
| String/default | 58.2n → 38.7n | −33% | 40 → 0 | −100% | 2 → 0 | −100% |
| String/xxhash | 32.9n → 13.3n | −60% | 32 → 0 | −100% | 1 → 0 | −100% |
| **geomean** | 221n → 184n | **−44%** | | | | |



## Bench raw output

```
goos: darwin
goarch: arm64
pkg: github.com/gohugoio/hashstructure
cpu: Apple M1 Pro
                                    │ 22994890b2a9beb2ad7d70f837f714ee3575d1e9.bench │     feat-misc20260730_2.bench      │
                                    │                     sec/op                     │   sec/op     vs base               │
Map/default-10                                                           2.252µ ± 5%   1.922µ ± 3%  -14.61% (p=0.002 n=6)
Map/no-op_unwrap-10                                                      2.335µ ± 2%   2.004µ ± 0%  -14.20% (p=0.002 n=6)
Struct/value-10                                                          180.2n ± 0%   165.4n ± 0%   -8.22% (p=0.002 n=6)
Struct/pointer-10                                                        158.2n ± 0%   143.5n ± 0%   -9.29% (p=0.002 n=6)
Struct/pointer_predefined_hasher-10                                      151.5n ± 0%   134.9n ± 0%  -10.99% (p=0.002 n=6)
String/default-10                                                        28.76n ± 1%   37.88n ± 0%  +31.69% (p=0.002 n=6)
String/xxhash-10                                                         16.54n ± 2%   12.96n ± 0%  -21.65% (p=0.002 n=6)
geomean                                                                  195.2n        179.7n        -7.94%

                                    │ 22994890b2a9beb2ad7d70f837f714ee3575d1e9.bench │       feat-misc20260730_2.bench        │
                                    │                      B/op                      │    B/op     vs base                    │
Map/default-10                                                         632.00 ± 0%     64.00 ± 0%   -89.87% (p=0.002 n=6)
Map/no-op_unwrap-10                                                    624.00 ± 0%     64.00 ± 0%   -89.74% (p=0.002 n=6)
Struct/value-10                                                        112.00 ± 0%     16.00 ± 0%   -85.71% (p=0.002 n=6)
Struct/pointer-10                                                       96.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
Struct/pointer_predefined_hasher-10                                     88.00 ± 0%      0.00 ± 0%  -100.00% (p=0.002 n=6)
String/default-10                                                       8.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
String/xxhash-10                                                        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
geomean                                                                            ²               ?                      ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                    │ 22994890b2a9beb2ad7d70f837f714ee3575d1e9.bench │       feat-misc20260730_2.bench        │
                                    │                   allocs/op                    │ allocs/op   vs base                    │
Map/default-10                                                         39.000 ± 0%     4.000 ± 0%   -89.74% (p=0.002 n=6)
Map/no-op_unwrap-10                                                    38.000 ± 0%     4.000 ± 0%   -89.47% (p=0.002 n=6)
Struct/value-10                                                         5.000 ± 0%     1.000 ± 0%   -80.00% (p=0.002 n=6)
Struct/pointer-10                                                       4.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
Struct/pointer_predefined_hasher-10                                     3.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
String/default-10                                                       1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.002 n=6)
String/xxhash-10                                                        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=6) ¹
geomean                                                                            ²               ?                      ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```

Interestingly, if we compared it to the repository we forked from:

```
goos: darwin
goarch: arm64
pkg: github.com/gohugoio/hashstructure
cpu: Apple M1 Pro
                                    │ benchcmp.bench │     feat-misc20260730_2.bench      │
                                    │     sec/op     │   sec/op     vs base               │
Map/default-10                           2.955µ ± 5%   1.956µ ± 4%  -33.79% (p=0.002 n=6)
Struct/value-10                          277.6n ± 0%   169.0n ± 0%  -39.14% (p=0.002 n=6)
Struct/pointer-10                        276.8n ± 1%   146.5n ± 0%  -47.07% (p=0.002 n=6)
Struct/pointer_predefined_hasher-10      268.5n ± 2%   138.2n ± 1%  -48.52% (p=0.002 n=6)
String/default-10                        58.17n ± 0%   38.69n ± 0%  -33.49% (p=0.002 n=6)
String/xxhash-10                         32.90n ± 0%   13.31n ± 1%  -59.53% (p=0.002 n=6)
Map/no-op_unwrap-10                                    2.102µ ± 2%
geomean                                  221.0n        184.4n       -44.40%

                                    │ benchcmp.bench │       feat-misc20260730_2.bench        │
                                    │      B/op      │    B/op     vs base                    │
Map/default-10                          1630.00 ± 0%   64.00 ± 0%   -96.07% (p=0.002 n=6)
Struct/value-10                          160.00 ± 0%   16.00 ± 0%   -90.00% (p=0.002 n=6)
Struct/pointer-10                         160.0 ± 0%     0.0 ± 0%  -100.00% (p=0.002 n=6)
Struct/pointer_predefined_hasher-10       152.0 ± 0%     0.0 ± 0%  -100.00% (p=0.002 n=6)
String/default-10                         40.00 ± 0%    0.00 ± 0%  -100.00% (p=0.002 n=6)
String/xxhash-10                          32.00 ± 0%    0.00 ± 0%  -100.00% (p=0.002 n=6)
Map/no-op_unwrap-10                                    64.00 ± 0%
geomean                                   141.8                    ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                                    │ benchcmp.bench │       feat-misc20260730_2.bench        │
                                    │   allocs/op    │ allocs/op   vs base                    │
Map/default-10                          101.000 ± 0%   4.000 ± 0%   -96.04% (p=0.002 n=6)
Struct/value-10                          11.000 ± 0%   1.000 ± 0%   -90.91% (p=0.002 n=6)
Struct/pointer-10                         11.00 ± 0%    0.00 ± 0%  -100.00% (p=0.002 n=6)
Struct/pointer_predefined_hasher-10       10.00 ± 0%    0.00 ± 0%  -100.00% (p=0.002 n=6)
String/default-10                         2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
String/xxhash-10                          1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
Map/no-op_unwrap-10                                    4.000 ± 0%
geomean                                   7.907                    ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```